### PR TITLE
Fix sound and light syncing

### DIFF
--- a/DMXEngine/DMXStateMachine.cs
+++ b/DMXEngine/DMXStateMachine.cs
@@ -197,13 +197,7 @@ namespace DMXEngine
                         ClearAllActiveEvents();
                     }
 
-                    _activeEvents.Add(eventName, new ActiveEvent(DateTime.Now, foundEvent.RepeatCount, continuous));
-
-                    if (_eventChangeQueue != null)
-                    {
-                        _eventChangeQueue.AddToQueue(new EventChange(eventName, true));
-                    }
-
+                    // Start sound first before lighting event so the timing will be more consistent
                     if (foundEvent.SoundData != null && foundEvent.SoundData.Length > 0)
                     {
                         var fileExt = Path.GetExtension(foundEvent.SoundFileName);
@@ -220,6 +214,14 @@ namespace DMXEngine
                         _waveOut = new WaveOut();
                         _waveOut.Init(stream);
                         _waveOut.Play();
+                    }
+
+
+                    _activeEvents.Add(eventName, new ActiveEvent(DateTime.Now, foundEvent.RepeatCount, continuous));
+
+                    if (_eventChangeQueue != null)
+                    {
+                        _eventChangeQueue.AddToQueue(new EventChange(eventName, true));
                     }
                 }
             }

--- a/DMXForGamers/Properties/AssemblyInfo.cs
+++ b/DMXForGamers/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.1.0")]
+[assembly: AssemblyFileVersion("1.0.1.0")]


### PR DESCRIPTION
Load sound first before lighting events are started to keep the sound and lighting in sync better